### PR TITLE
Support building for oc as oc-ramen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 kubectl-ramen
+oc-ramen
 cover.out

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-PROG := kubectl-ramen
+# We can run as kubectl-ramen or oc-ramen.
+HOST := kubectl
 
+prog := $(HOST)-ramen
 cover := cover.out
-output := $(cover) $(PROG)
+output := $(cover) $(prog)
 
-all: $(PROG)
+all: $(prog)
 
 test: reuse quick-tests
 
@@ -19,8 +21,8 @@ cover:
 reuse:
 	reuse lint
 
-$(PROG):
-	go build -o $(PROG)
+$(prog):
+	go build -o $(prog)
 
 clean:
 	rm -f $(output)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ prog := $(HOST)-ramen
 cover := cover.out
 output := $(cover) $(prog)
 
-all: $(prog)
+all:
+	go build -o $(prog)
 
 test: reuse quick-tests
 
@@ -20,9 +21,6 @@ cover:
 
 reuse:
 	reuse lint
-
-$(prog):
-	go build -o $(prog)
 
 clean:
 	rm -f $(output)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ kubectl ramen disable --clusterset rdr --namespace busybox-sample
 kubectl ramen undeploy --clusterset rdr
 ```
 
+## Build
+
+Build for `kubectl` (default):
+
+```shell
+make
+```
+
+Build for `oc`:
+
+```shell
+make HOST=oc
+```
+
+## Install
+
+Copy the executables to a directory in the PATH:
+
+```shell
+cp kubectl-ramen /usr/loca/bin
+```
+
 ## Status
 
 This is work in progress; only some commands are implemented.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/spf13/cobra"
 )
@@ -14,42 +15,45 @@ var (
 	verbose bool
 
 	rootExample = `  # Add clusterset from drenv environment file
-  kubectl ramen clusterset add-env rdr --env-file regional-dr.yaml
+  %[1]s clusterset add-env rdr --env-file regional-dr.yaml
 
   # Add clusterset from kubeconfigs
-  kubectl ramen clusterset add-cfg rdr --hub hub.cfg --cluster1 c1.cfg --cluster2 c2.cfg
+  %[1]s clusterset add-cfg rdr --hub hub.cfg --cluster1 c1.cfg --cluster2 c2.cfg
 
   # Deploy ramen in clusterset "rdr"
-  kubectl ramen deploy --clusterset rdr
+  %[1]s deploy --clusterset rdr
 
   # Enable DR for application "busybox-sample"
-  kubectl ramen enable --clusterset rdr --namespace busybox-sample
+  %[1]s enable --clusterset rdr --namespace busybox-sample
 
   # Print application "busybox-sample" status
-  kubectl ramen status --clusterset rdr --namespace busybox-sample
+  %[1]s status --clusterset rdr --namespace busybox-sample
 
   # Watch application "busybox-sample" status
-  kubectl ramen status --clusterset rdr --namespace busybox-sample --watch
+  %[1]s status --clusterset rdr --namespace busybox-sample --watch
 
   # Failover application to the other managed cluster
-  kubectl ramen failover --clusterset rdr --namespace busybox-sample
+  %[1]s failover --clusterset rdr --namespace busybox-sample
 
   # Relocate application to the other managed cluster
-  kubectl ramen relocate --clusterset rdr --namespace busybox-sample
+  %[1]s relocate --clusterset rdr --namespace busybox-sample
 
   # Disable DR for the busybox-sample application
-  kubectl ramen disable --clusterset rdr --namespace busybox-sample
+  %[1]s disable --clusterset rdr --namespace busybox-sample
 
   # Undeploy ramen in clusterset "rdr"
-  kubectl ramen undeploy --clusterset rdr`
+  %[1]s undeploy --clusterset rdr`
 )
 
+// Can be `kubectl-ramen` or `oc-ramen`.
+var executableName = path.Base(os.Args[0])
+
 var rootCmd = &cobra.Command{
-	// NOTE: using No-Break-Space (U+00A0) since only the first word
-	// is considered as the command name.
-	Use:     "kubectl\u00A0ramen",
-	Short:   "The kubectl ramen plugin manages Ramen DR",
-	Example: rootExample,
+	// We cannot use `kubectl ramen` since the only first word is used by
+	// cobra. See https://github.com/spf13/cobra/issues/2017.
+	Use:     executableName,
+	Short:   fmt.Sprintf("The %[1]s plugin manages Ramen DR", executableName),
+	Example: fmt.Sprintf(rootExample, executableName),
 }
 
 func init() {


### PR DESCRIPTION
The Makefile can be customized to build oc-ramen plugin, and the root command uses the executable name to to create the right help output.

Example of running in `kubectl`:

    $ kubectl ramen clusterset -h
    This commands adds or removes clusterset configurations
    that can be used later with the --clusterset option.

    Usage:
      kubectl-ramen clusterset [flags]
      kubectl-ramen clusterset [command]

    ...

Example of running in `oc`:

    $ oc ramen clusterset -h
    This commands adds or removes clusterset configurations
    that can be used later with the --clusterset option.

    Usage:
      oc-ramen clusterset [flags]
      oc-ramen clusterset [command]

    ...