### PR TITLE
Support adding clusterset from kubeconfigs

### DIFF
--- a/cmd/addcfg.go
+++ b/cmd/addcfg.go
@@ -4,8 +4,10 @@
 package cmd
 
 import (
-	"fmt"
+	"log"
 
+	"github.com/nirs/kubectl-ramen/config"
+	"github.com/nirs/kubectl-ramen/config/kube"
 	"github.com/spf13/cobra"
 )
 
@@ -22,11 +24,14 @@ var addCfgCmd = &cobra.Command{
 created from the hub and the managed clusters`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if verbose {
-			fmt.Printf("Adding clusterset %q from kubeconfigs\n", args[0])
-			fmt.Printf("  hub: %q\n", hubKubeconfig)
-			fmt.Printf("  cluster1: %q\n", cluster1Kubeconfig)
-			fmt.Printf("  cluster2: %q\n", cluster2Kubeconfig)
+		configset, err := kube.NewConfigSet(hubKubeconfig, cluster1Kubeconfig, cluster2Kubeconfig)
+		if err != nil {
+			log.Fatalf("Canot load configs: %s", err)
+		}
+		store := config.DefaultStore()
+		err = store.AddClusterSetFromConfigs(args[0], configset)
+		if err != nil {
+			log.Fatalf("Cannot add clusterset: %s", err)
 		}
 	},
 }

--- a/config/config.go
+++ b/config/config.go
@@ -91,6 +91,8 @@ func (s *Store) AddClusterSetFromEnv(name string, env *drenv.Environment) error 
 	return nil
 }
 
+// Creating clusterset from drev environment.
+
 func (s *Store) newClusterSetFromEnv(name string, env *drenv.Environment, dir string) *api.ClusterSet {
 	clusterset := &api.ClusterSet{
 		Name:     name,
@@ -113,20 +115,6 @@ func (s *Store) newClusterSetFromEnv(name string, env *drenv.Environment, dir st
 	}
 
 	return clusterset
-}
-
-func (s *Store) createClusterSetDir(path string) error {
-	err := os.MkdirAll(s.clustersetsDir(), 0700)
-	if err != nil {
-		return err
-	}
-
-	err = os.Mkdir(path, 0700)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (s *Store) copyClustersConfigs(clusterset *api.ClusterSet, dir string) error {
@@ -157,6 +145,22 @@ func (s *Store) copyKubeConfigFor(cluster *api.Cluster) error {
 	}
 
 	return clientcmd.WriteToFile(*config, cluster.Kubeconfig)
+}
+
+// Storing clusterset
+
+func (s *Store) createClusterSetDir(path string) error {
+	err := os.MkdirAll(s.clustersetsDir(), 0700)
+	if err != nil {
+		return err
+	}
+
+	err = os.Mkdir(path, 0700)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *Store) writeClusterSet(clusterset *api.ClusterSet, dir string) error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -230,7 +230,7 @@ func checkClusterSet(t *testing.T, clusterset *api.ClusterSet, name string, topo
 	if clusterset.Name != name {
 		t.Fatalf("Expected clusterset name %q, got %q", name, clusterset.Name)
 	}
-	if clusterset.Topology != api.RegionalDR {
+	if clusterset.Topology != topology {
 		t.Fatalf("Expected clusterset topology %q, got %q", topology, clusterset.Topology)
 	}
 }

--- a/config/kube/kube.go
+++ b/config/kube/kube.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"path"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+type Config struct {
+	Filename string
+	Config   *api.Config
+}
+
+type ConfigSet struct {
+	Hub      *Config
+	Cluster1 *Config
+	Cluster2 *Config
+}
+
+func NewConfigSet(hub string, cluster1 string, cluster2 string) (*ConfigSet, error) {
+	hubConfig, err := loadConfig(hub)
+	if err != nil {
+		return nil, err
+	}
+	cluster1Config, err := loadConfig(cluster1)
+	if err != nil {
+		return nil, err
+	}
+	cluster2Config, err := loadConfig(cluster2)
+	if err != nil {
+		return nil, err
+	}
+	return &ConfigSet{
+		Hub:      hubConfig,
+		Cluster1: cluster1Config,
+		Cluster2: cluster2Config,
+	}, nil
+}
+
+func loadConfig(filename string) (*Config, error) {
+	config, err := clientcmd.LoadFromFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	err = clientcmd.Validate(*config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Config{
+		Filename: path.Base(filename),
+		Config:   config,
+	}, nil
+}

--- a/config/kube/kube_test.go
+++ b/config/kube/kube_test.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kube_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/nirs/kubectl-ramen/config/kube"
+)
+
+func TestConfigKubeNewConfigSet(t *testing.T) {
+	type cluster struct {
+		filename string
+		context  string
+	}
+	hub := cluster{
+		filename: "perf1.kubeconfig",
+		context:  "default/api-perf1-examle-com:1234/kube:admin",
+	}
+	cluster1 := cluster{
+		filename: "perf2.kubeconfig",
+		context:  "default/api-perf2-examle-com:1234/kube:admin",
+	}
+	cluster2 := cluster{
+		filename: "perf3.kubeconfig",
+		context:  "default/api-perf3-examle-com:1234/kube:admin",
+	}
+
+	c, err := kube.NewConfigSet(
+		filepath.Join("testdata", hub.filename),
+		filepath.Join("testdata", cluster1.filename),
+		filepath.Join("testdata", cluster2.filename),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c.Hub.Filename != hub.filename {
+		t.Fatalf("Expected Hub filename %q, got %q", hub.filename, c.Hub.Filename)
+	}
+	if c.Hub.Config.CurrentContext != hub.context {
+		t.Fatalf("Expected hub context %q, got %q", hub.context, c.Hub.Config.CurrentContext)
+	}
+
+	if c.Cluster1.Filename != cluster1.filename {
+		t.Fatalf("Expected Hub filename %q, got %q", cluster1.filename, c.Cluster1.Filename)
+	}
+	if c.Cluster1.Config.CurrentContext != cluster1.context {
+		t.Fatalf("Expected hub context %q, got %q", cluster1.context, c.Cluster1.Config.CurrentContext)
+	}
+
+	if c.Cluster2.Filename != cluster2.filename {
+		t.Fatalf("Expected Hub filename %q, got %q", cluster2.filename, c.Cluster2.Filename)
+	}
+	if c.Cluster2.Config.CurrentContext != cluster2.context {
+		t.Fatalf("Expected hub context %q, got %q", cluster2.context, c.Cluster2.Config.CurrentContext)
+	}
+}

--- a/config/kube/testdata/perf1.kubeconfig
+++ b/config/kube/testdata/perf1.kubeconfig
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://api.perf1.example.com:1234
+  name: api-perf1-example-com:1234
+contexts:
+- context:
+    cluster: api-perf1-example-com:1234
+    namespace: default
+    user: kube:admin/api-perf1-examle-com:1234
+  name: default/api-perf1-examle-com:1234/kube:admin
+current-context: default/api-perf1-examle-com:1234/kube:admin
+kind: Config
+preferences: {}
+users:
+- name: kube:admin/api-perf1-examle-com:1234
+  user:
+    token: sha256~dQ2o7Ojwi9jV6+t63hKNuD8GbsrXpj0HJnDVt0ESGLs

--- a/config/kube/testdata/perf1.kubeconfig.license
+++ b/config/kube/testdata/perf1.kubeconfig.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0

--- a/config/kube/testdata/perf2.kubeconfig
+++ b/config/kube/testdata/perf2.kubeconfig
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://api.perf2.examle.com:1234
+  name: api-perf2-examle-com:1234
+contexts:
+- context:
+    cluster: api-perf2-examle-com:1234
+    namespace: default
+    user: kube:admin/api-perf2-examle-com:1234
+  name: default/api-perf2-examle-com:1234/kube:admin
+current-context: default/api-perf2-examle-com:1234/kube:admin
+kind: Config
+preferences: {}
+users:
+- name: kube:admin/api-perf2-examle-com:1234
+  user:
+    token: sha256~syyU7dO76UFm0djbP56xNDvwtvEfZbZLi2Cazih9cyw

--- a/config/kube/testdata/perf2.kubeconfig.license
+++ b/config/kube/testdata/perf2.kubeconfig.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0

--- a/config/kube/testdata/perf3.kubeconfig
+++ b/config/kube/testdata/perf3.kubeconfig
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://api.perf3.examle.com:1234
+  name: api-perf3-examle-com:1234
+contexts:
+- context:
+    cluster: api-perf3-examle-com:1234
+    namespace: default
+    user: kube:admin/api-perf3-examle-com:1234
+  name: default/api-perf3-examle-com:1234/kube:admin
+current-context: default/api-perf3-examle-com:1234/kube:admin
+kind: Config
+preferences: {}
+users:
+- name: kube:admin/api-perf3-examle-com:1234
+  user:
+    token: sha256~kwp7Syx8lNKb/bkigzyNlIezNy403oi6WXFcYDUz3gE

--- a/config/kube/testdata/perf3.kubeconfig.license
+++ b/config/kube/testdata/perf3.kubeconfig.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
We can add now clusterset from kubeconfigs.

Example run, using openshift testing clusters:

    % kubectl ramen clusterset add-cfg cb-lab \
        --hub perf1.kubeconfig \
        --cluster1 perf2.kubeconfig \
        --cluster2 perf3.kubeconfig

    % kubectl ramen clusterset
    cb-lab

    % tree ~/.config/kubectl-ramen/clustersets
    /Users/nir/.config/kubectl-ramen/clustersets
    └── cb-lab
        ├── config.yaml
        ├── perf1.kubeconfig
        ├── perf2.kubeconfig
        └── perf3.kubeconfig

    % cat ~/.config/kubectl-ramen/clustersets/cb-lab/config.yaml
    cluster1:
      kubeconfig: /Users/nir/.config/kubectl-ramen/clustersets/cb-lab/perf2.kubeconfig
      name: perf2
    cluster2:
      kubeconfig: /Users/nir/.config/kubectl-ramen/clustersets/cb-lab/perf3.kubeconfig
      name: perf3
    hub:
      kubeconfig: /Users/nir/.config/kubectl-ramen/clustersets/cb-lab/perf1.kubeconfig
      name: perf1
    name: cb-lab
    topology: ""

Issues:

- We don't know the cluster topology. Can be solved by another command
  line, but maybe we can extract this info from the cluster.