### PR TITLE
Add completion helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ Copy the executables to a directory in the PATH:
 cp kubectl-ramen /usr/local/bin
 ```
 
+To enable completions in kubectl, copy the completion helper script to a
+directory in the PATH
+
+```
+cp kubectl_complete-ramen /usr/local/bin
+```
+
+Example completion:
+
+```
+$ kubectl ramen clusterset [TAB]
+add-cfg  -- Add a clusterset from kubeconfigs files
+add-env  -- Add a clusterset from drenv environment file
+remove   -- Remove a clusterset
+```
+
 ## Status
 
 This is work in progress; only some commands are implemented.

--- a/kubectl_complete-ramen
+++ b/kubectl_complete-ramen
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+kubectl-ramen __complete "$@"


### PR DESCRIPTION
Copying the completion helper to the PATH enables completions when running the plugin in kubectl.